### PR TITLE
feat: various changes to how colour is handled

### DIFF
--- a/Controllers/RootOptionsController.h
+++ b/Controllers/RootOptionsController.h
@@ -3,3 +3,19 @@
 @interface RootOptionsController : UITableViewController
 
 @end
+
+@interface UIView ()
+- (UIViewController*)_viewControllerForAncestor;
+@end
+
+@interface UITableViewCellWithColorWell : UITableViewCell <UIColorPickerViewControllerDelegate>
+@property (strong, nonatomic) UIColorWell *colorWell;
+#ifdef __IPHONE_15_0
+- (void)colorPickerViewController:(UIColorPickerViewController*)viewController 
+                   didSelectColor:(UIColor*)color;
+                     continuously:(BOOL)continuously;
+#else
+- (void)colorPickerViewControllerDidSelectColor:(UIColorPickerViewController*)viewController;
+#endif
+- (void)presentColorPicker:(UITableViewCell*)sender;
+@end

--- a/Controllers/RootOptionsController.m
+++ b/Controllers/RootOptionsController.m
@@ -3,7 +3,6 @@
 #import "OverlayOptionsController.h"
 #import "TabBarOptionsController.h"
 #import "CreditsController.h"
-#import "ColourOptionsController.h"
 #import "ShortsOptionsController.h"
 #import "RebornSettingsController.h"
 #import "DownloadsController.h"
@@ -13,6 +12,42 @@
 #import "../iOS15Fix.h"
 
 static int __isOSVersionAtLeast(int major, int minor, int patch) { NSOperatingSystemVersion version; version.majorVersion = major; version.minorVersion = minor; version.patchVersion = patch; return [[NSProcessInfo processInfo] isOperatingSystemAtLeastVersion:version]; }
+
+UIColor *hexColour() {
+    NSData *colorData = [[NSUserDefaults standardUserDefaults] objectForKey:@"kYTRebornColourOptionsVTwo"];
+    NSKeyedUnarchiver *unarchiver = [[NSKeyedUnarchiver alloc] initForReadingFromData:colorData error:nil];
+    [unarchiver setRequiresSecureCoding:NO];
+    return [unarchiver decodeObjectForKey:NSKeyedArchiveRootObjectKey];
+}
+
+@implementation UITableViewCellWithColorWell
+#ifdef __IPHONE_15_0
+- (void)colorPickerViewController:(UIColorPickerViewController*)viewController 
+                   didSelectColor:(UIColor*)color;
+                     continuously:(BOOL)continuously {
+#else
+- (void)colorPickerViewControllerDidSelectColor:(UIColorPickerViewController*)viewController {
+    UIColor* color = viewController.selectedColor;
+#endif
+    NSData *colorData = [NSKeyedArchiver archivedDataWithRootObject:color requiringSecureCoding:nil error:nil];
+    [[NSUserDefaults standardUserDefaults] setObject:colorData forKey:@"kYTRebornColourOptionsVTwo"];
+    [[NSUserDefaults standardUserDefaults] synchronize];
+    CFNotificationCenterPostNotification(CFNotificationCenterGetDarwinNotifyCenter(), CFSTR("h.ryan.youtubereborn.prefs.colour"), NULL, NULL, YES);
+}
+- (void)presentColorPicker:(UITableViewCell*)sender {
+    NSUserDefaults* defaults = [NSUserDefaults standardUserDefaults];
+    UIColor* color = hexColour();
+
+    UIColorPickerViewController* colorPicker = [[UIColorPickerViewController alloc] init];
+    colorPicker.popoverPresentationController.sourceView = self;
+    colorPicker.supportsAlpha = NO;
+    colorPicker.delegate = self;
+    colorPicker.selectedColor = color;
+
+    UIViewController* rootViewController = self._viewControllerForAncestor;
+    [rootViewController presentViewController:colorPicker animated:YES completion:nil];
+}
+@end
 
 @interface RootOptionsController ()
 @end
@@ -60,10 +95,10 @@ static int __isOSVersionAtLeast(int major, int minor, int patch) { NSOperatingSy
         }
     }
     if (section == 2) {
-        return 6;
+        return 5;
     }
     if (section == 3) {
-        return 8;
+        return 9;
     }
     if (section == 4) {
         return 2;
@@ -116,24 +151,45 @@ static int __isOSVersionAtLeast(int major, int minor, int patch) { NSOperatingSy
                 cell.accessoryType = UITableViewCellAccessoryDisclosureIndicator;
             }
             if(indexPath.row == 3) {
-                cell.textLabel.text = @"Colour Options";
-                cell.accessoryType = UITableViewCellAccessoryDisclosureIndicator;
-            }
-            if(indexPath.row == 4) {
                 cell.textLabel.text = @"Search Options";
                 cell.accessoryType = UITableViewCellAccessoryDisclosureIndicator;
             }
-            if(indexPath.row == 5) {
+            if(indexPath.row == 4) {
                 cell.textLabel.text = @"Shorts Options";
                 cell.accessoryType = UITableViewCellAccessoryDisclosureIndicator;
             }
-            if(indexPath.row == 6) {
+            if(indexPath.row == 5) {
                 cell.textLabel.text = @"SponsorBlock Options";
                 cell.accessoryType = UITableViewCellAccessoryDisclosureIndicator;
             }
         }
         if(indexPath.section == 3) {
             if(indexPath.row == 0) {
+                UITableViewCellWithColorWell *cell2 = [tableView dequeueReusableCellWithIdentifier:@"RootTableViewCell2"];
+                if (cell2 == nil) {
+                    cell2 = [[UITableViewCellWithColorWell alloc] initWithStyle:UITableViewCellStyleSubtitle reuseIdentifier:nil];
+                    cell2.textLabel.adjustsFontSizeToFitWidth = true;
+                    if (self.traitCollection.userInterfaceStyle == UIUserInterfaceStyleLight) {
+                        cell2.backgroundColor = [UIColor colorWithRed:1.0 green:1.0 blue:1.0 alpha:1.0];
+                        cell2.textLabel.textColor = [UIColor blackColor];
+                    }
+                    else {
+                        cell2.backgroundColor = [UIColor colorWithRed:0.110 green:0.110 blue:0.118 alpha:1.0];
+                        cell2.textLabel.textColor = [UIColor whiteColor];
+                    }
+                    UIColorWell* colorWell = [[UIColorWell alloc] initWithFrame:CGRectMake(0, 0, 32, 32)];
+                    [colorWell addTarget:cell2
+                                action:@selector(presentColorPicker:)
+                        forControlEvents:UIControlEventTouchUpInside];
+                    colorWell.selectedColor = hexColour();
+
+                    cell2.textLabel.text = @"Colour Options";
+                    cell2.colorWell = colorWell;
+                    cell2.accessoryView = colorWell;
+                }
+                return cell2;
+            }
+            if(indexPath.row == 1) {
                 cell.textLabel.text = @"Enable iPad Style On iPhone";
                 cell.selectionStyle = UITableViewCellSelectionStyleNone;
                 UISwitch *enableiPadStyleOniPhone = [[UISwitch alloc] initWithFrame:CGRectZero];
@@ -141,7 +197,7 @@ static int __isOSVersionAtLeast(int major, int minor, int patch) { NSOperatingSy
                 enableiPadStyleOniPhone.on = [[NSUserDefaults standardUserDefaults] boolForKey:@"kEnableiPadStyleOniPhone"];
                 cell.accessoryView = enableiPadStyleOniPhone;
             }
-            if(indexPath.row == 1) {
+            if(indexPath.row == 2) {
                 cell.textLabel.text = @"Unlock UHD Quality";
                 cell.selectionStyle = UITableViewCellSelectionStyleNone;
                 UISwitch *unlockUHDQuality = [[UISwitch alloc] initWithFrame:CGRectZero];
@@ -149,7 +205,7 @@ static int __isOSVersionAtLeast(int major, int minor, int patch) { NSOperatingSy
                 unlockUHDQuality.on = [[NSUserDefaults standardUserDefaults] boolForKey:@"kUnlockUHDQuality"];
                 cell.accessoryView = unlockUHDQuality;
             }
-            if(indexPath.row == 2) {
+            if(indexPath.row == 3) {
                 cell.textLabel.text = @"No Cast Button";
                 cell.selectionStyle = UITableViewCellSelectionStyleNone;
                 UISwitch *noCastButton = [[UISwitch alloc] initWithFrame:CGRectZero];
@@ -157,7 +213,7 @@ static int __isOSVersionAtLeast(int major, int minor, int patch) { NSOperatingSy
                 noCastButton.on = [[NSUserDefaults standardUserDefaults] boolForKey:@"kNoCastButton"];
                 cell.accessoryView = noCastButton;
             }
-            if(indexPath.row == 3) {
+            if(indexPath.row == 4) {
                 cell.textLabel.text = @"No Notification Button";
                 cell.selectionStyle = UITableViewCellSelectionStyleNone;
                 UISwitch *noNotificationButton = [[UISwitch alloc] initWithFrame:CGRectZero];
@@ -165,7 +221,7 @@ static int __isOSVersionAtLeast(int major, int minor, int patch) { NSOperatingSy
                 noNotificationButton.on = [[NSUserDefaults standardUserDefaults] boolForKey:@"kNoNotificationButton"];
                 cell.accessoryView = noNotificationButton;
             }
-            if(indexPath.row == 4) {
+            if(indexPath.row == 5) {
                 cell.textLabel.text = @"No Search Button";
                 cell.selectionStyle = UITableViewCellSelectionStyleNone;
                 UISwitch *noSearchButton = [[UISwitch alloc] initWithFrame:CGRectZero];
@@ -173,7 +229,7 @@ static int __isOSVersionAtLeast(int major, int minor, int patch) { NSOperatingSy
                 noSearchButton.on = [[NSUserDefaults standardUserDefaults] boolForKey:@"kNoSearchButton"];
                 cell.accessoryView = noSearchButton;
             }
-            if(indexPath.row == 5) {
+            if(indexPath.row == 6) {
                 cell.textLabel.text = @"Disable YouTube Kids";
                 cell.selectionStyle = UITableViewCellSelectionStyleNone;
                 UISwitch *disableYouTubeKidsPopup = [[UISwitch alloc] initWithFrame:CGRectZero];
@@ -181,7 +237,7 @@ static int __isOSVersionAtLeast(int major, int minor, int patch) { NSOperatingSy
                 disableYouTubeKidsPopup.on = [[NSUserDefaults standardUserDefaults] boolForKey:@"kDisableYouTubeKidsPopup"];
                 cell.accessoryView = disableYouTubeKidsPopup;
             }
-            if(indexPath.row == 6) {
+            if(indexPath.row == 7) {
                 cell.textLabel.text = @"Disable Hints";
                 cell.selectionStyle = UITableViewCellSelectionStyleNone;
                 UISwitch *disableHints = [[UISwitch alloc] initWithFrame:CGRectZero];
@@ -189,7 +245,7 @@ static int __isOSVersionAtLeast(int major, int minor, int patch) { NSOperatingSy
                 disableHints.on = [[NSUserDefaults standardUserDefaults] boolForKey:@"kDisableHints"];
                 cell.accessoryView = disableHints;
             }
-            if(indexPath.row == 7) {
+            if(indexPath.row == 8) {
                 cell.textLabel.text = @"Hide YouTube Logo";
                 cell.selectionStyle = UITableViewCellSelectionStyleNone;
                 UISwitch *hideYouTubeLogo = [[UISwitch alloc] initWithFrame:CGRectZero];
@@ -262,27 +318,20 @@ static int __isOSVersionAtLeast(int major, int minor, int patch) { NSOperatingSy
             [self presentViewController:tabBarOptionsControllerView animated:YES completion:nil];
         }
         if(indexPath.row == 3) {
-            ColourOptionsController *colourOptionsController = [[ColourOptionsController alloc] init];
-            UINavigationController *colourOptionsControllerView = [[UINavigationController alloc] initWithRootViewController:colourOptionsController];
-            colourOptionsControllerView.modalPresentationStyle = UIModalPresentationFullScreen;
-
-            [self presentViewController:colourOptionsControllerView animated:YES completion:nil];
-        }
-        if(indexPath.row == 4) {
             SearchOptionsController *searchOptionsController = [[SearchOptionsController alloc] init];
             UINavigationController *searchOptionsControllerView = [[UINavigationController alloc] initWithRootViewController:searchOptionsController];
             searchOptionsControllerView.modalPresentationStyle = UIModalPresentationFullScreen;
 
             [self presentViewController:searchOptionsControllerView animated:YES completion:nil];
         }
-        if(indexPath.row == 5) {
+        if(indexPath.row == 4) {
             ShortsOptionsController *shortsOptionsController = [[ShortsOptionsController alloc] init];
             UINavigationController *shortsOptionsControllerView = [[UINavigationController alloc] initWithRootViewController:shortsOptionsController];
             shortsOptionsControllerView.modalPresentationStyle = UIModalPresentationFullScreen;
 
             [self presentViewController:shortsOptionsControllerView animated:YES completion:nil];
         }
-        if(indexPath.row == 6) {
+        if(indexPath.row == 5) {
             SponsorBlockOptionsController *sponsorBlockOptionsController = [[SponsorBlockOptionsController alloc] init];
             UINavigationController *sponsorBlockOptionsControllerView = [[UINavigationController alloc] initWithRootViewController:sponsorBlockOptionsController];
             sponsorBlockOptionsControllerView.modalPresentationStyle = UIModalPresentationFullScreen;

--- a/Tweak.h
+++ b/Tweak.h
@@ -79,6 +79,7 @@
 // Tweak Variables
 
 extern NSString *videoTime;
+extern UIColor *rebornCustomColour;
 extern NSURL *directURL;
 extern NSURL *streamURL;
 

--- a/Tweak.xm
+++ b/Tweak.xm
@@ -9,6 +9,7 @@
 #import "Tweak.h"
 
 NSString *YTApiKey = @"AIzaSyAcHI73xntvCiURGWERFcJxm5vX12p5bN8";
+UIColor *rebornCustomColour;
 
 UIColor *hexColour() {
     NSData *colorData = [[NSUserDefaults standardUserDefaults] objectForKey:@"kYTRebornColourOptionsVTwo"];
@@ -65,7 +66,7 @@ YTUserDefaults *ytThemeSettings;
 
         UIView *rebornView = [[UIView alloc] initWithFrame:CGRectMake(0, 10, childView.bounds.size.width, 51)];
         [rebornView setUserInteractionEnabled:YES];
-        rebornView.backgroundColor = [[UIColor blackColor] colorWithAlphaComponent:0.0];
+        rebornView.backgroundColor = [UIColor clearColor];
 
         UILabel *label = [[UILabel alloc] initWithFrame:CGRectMake(16, 0, rebornView.frame.size.width, 51)];
         label.text = @"YT Reborn Settings";
@@ -1120,55 +1121,55 @@ NSURL *streamURL;
 %hook UIView
 - (void)setBackgroundColor:(UIColor *)color {
     if([self.nextResponder isKindOfClass:NSClassFromString(@"YTPivotBarView")]) {
-        color = hexColour();
+        color = rebornCustomColour;
     }
     if([self.nextResponder isKindOfClass:NSClassFromString(@"YTSlideForActionsView")]) {
-        color = hexColour();
+        color = rebornCustomColour;
     }
     if([self.nextResponder isKindOfClass:NSClassFromString(@"YTChipCloudCell")]) {
-        color = hexColour();
+        color = rebornCustomColour;
     }
     if([self.nextResponder isKindOfClass:NSClassFromString(@"YTEngagementPanelView")]) {
-        color = hexColour();
+        color = rebornCustomColour;
     }
     if([self.nextResponder isKindOfClass:NSClassFromString(@"YTPlaylistPanelProminentThumbnailVideoCell")]) {
-        color = hexColour();
+        color = rebornCustomColour;
     }
     if([self.nextResponder isKindOfClass:NSClassFromString(@"YTPlaylistHeaderView")]) {
-        color = hexColour();
+        color = rebornCustomColour;
     }
     if([self.nextResponder isKindOfClass:NSClassFromString(@"YTAsyncCollectionView")]) {
-        color = hexColour();
+        color = rebornCustomColour;
     }
     if([self.nextResponder isKindOfClass:NSClassFromString(@"YTLinkCell")]) {
-        color = hexColour();
+        color = rebornCustomColour;
     }
     if([self.nextResponder isKindOfClass:NSClassFromString(@"YTMessageCell")]) {
-        color = hexColour();
+        color = rebornCustomColour;
     }
     if([self.nextResponder isKindOfClass:NSClassFromString(@"YTSearchView")]) {
-        color = hexColour();
+        color = rebornCustomColour;
     }
     if([self.nextResponder isKindOfClass:NSClassFromString(@"YTDrawerAvatarCell")]) {
-        color = hexColour();
+        color = rebornCustomColour;
     }
     if([self.nextResponder isKindOfClass:NSClassFromString(@"YTFeedHeaderView")]) {
-        color = hexColour();
+        color = rebornCustomColour;
     }
     if([self.nextResponder isKindOfClass:NSClassFromString(@"YCHLiveChatTextCell")]) {
-        color = hexColour();
+        color = rebornCustomColour;
     }
     if([self.nextResponder isKindOfClass:NSClassFromString(@"YCHLiveChatViewerEngagementCell")]) {
-        color = hexColour();
+        color = rebornCustomColour;
     }
     if([self.nextResponder isKindOfClass:NSClassFromString(@"YTCommentsHeaderView")]) {
-        color = hexColour();
+        color = rebornCustomColour;
     }
     if([self.nextResponder isKindOfClass:NSClassFromString(@"YCHLiveChatView")]) {
-        color = hexColour();
+        color = rebornCustomColour;
     }
     if([self.nextResponder isKindOfClass:NSClassFromString(@"YCHLiveChatTickerViewController")]) {
-        color = hexColour();
+        color = rebornCustomColour;
     }
     %orig;
 }
@@ -1186,232 +1187,232 @@ NSURL *streamURL;
     } else if([self.nextResponder isKindOfClass:NSClassFromString(@"YTFullscreenMetadataHighlightsCollectionViewController")]) {
         color = [[UIColor blackColor] colorWithAlphaComponent:0.0];
     } else {
-        color = hexColour();
+        color = rebornCustomColour;
     }
     %orig;
 }
 %end
 %hook YTPivotBarView
 - (void)setBackgroundColor:(UIColor *)color {
-    color = hexColour();
+    color = rebornCustomColour;
     %orig;
 }
 %end
 %hook YTHeaderView
 - (void)setBackgroundColor:(UIColor *)color {
-    color = hexColour();
+    color = rebornCustomColour;
     %orig;
 }
 %end
 %hook YTSubheaderContainerView
 - (void)setBackgroundColor:(UIColor *)color {
-    color = hexColour();
+    color = rebornCustomColour;
     %orig;
 }
 %end
 %hook YTAppView
 - (void)setBackgroundColor:(UIColor *)color {
-    color = hexColour();
+    color = rebornCustomColour;
     %orig;
 }
 %end
 %hook YTChannelListSubMenuView
 - (void)setBackgroundColor:(UIColor *)color {
-    color = hexColour();
+    color = rebornCustomColour;
     %orig;
 }
 %end
 %hook YTSlideForActionsView
 - (void)setBackgroundColor:(UIColor *)color {
-    color = hexColour();
+    color = rebornCustomColour;
     %orig;
 }
 %end
 %hook YTPageView
 - (void)setBackgroundColor:(UIColor *)color {
-    color = hexColour();
+    color = rebornCustomColour;
     %orig;
 }
 %end
 %hook YTWatchView
 - (void)setBackgroundColor:(UIColor *)color {
-    color = hexColour();
+    color = rebornCustomColour;
     %orig;
 }
 %end
 %hook YTPlaylistMiniBarView
 - (void)setBackgroundColor:(UIColor *)color {
-    color = hexColour();
+    color = rebornCustomColour;
     %orig;
 }
 %end
 %hook YTEngagementPanelHeaderView
 - (void)setBackgroundColor:(UIColor *)color {
-    color = hexColour();
+    color = rebornCustomColour;
     %orig;
 }
 %end
 %hook YTPlaylistPanelControlsView
 - (void)setBackgroundColor:(UIColor *)color {
-    color = hexColour();
+    color = rebornCustomColour;
     %orig;
 }
 %end
 %hook YTHorizontalCardListView
 - (void)setBackgroundColor:(UIColor *)color {
-    color = hexColour();
+    color = rebornCustomColour;
     %orig;
 }
 %end
 %hook YTWatchMiniBarView
 - (void)setBackgroundColor:(UIColor *)color {
-    color = hexColour();
+    color = rebornCustomColour;
     %orig;
 }
 %end
 %hook YTCreateCommentAccessoryView
 - (void)setBackgroundColor:(UIColor *)color {
-    color = hexColour();
+    color = rebornCustomColour;
     %orig;
 }
 %end
 %hook YTCreateCommentTextView
 - (void)setBackgroundColor:(UIColor *)color {
-    color = hexColour();
+    color = rebornCustomColour;
     %orig;
 }
 %end
 %hook YTSearchView
 - (void)setBackgroundColor:(UIColor *)color {
-    color = hexColour();
+    color = rebornCustomColour;
     %orig;
 }
 %end
 %hook YTVideoView
 - (void)setBackgroundColor:(UIColor *)color {
-    color = hexColour();
+    color = rebornCustomColour;
     %orig;
 }
 %end
 %hook YTSearchBoxView
 - (void)setBackgroundColor:(UIColor *)color {
-    color = hexColour();
+    color = rebornCustomColour;
     %orig;
 }
 %end
 %hook YTTabTitlesView
 - (void)setBackgroundColor:(UIColor *)color {
-    color = hexColour();
+    color = rebornCustomColour;
     %orig;
 }
 %end
 %hook YTPrivacyTosFooterView
 - (void)setBackgroundColor:(UIColor *)color {
-    color = hexColour();
+    color = rebornCustomColour;
     %orig;
 }
 %end
 %hook YTOfflineStorageUsageView
 - (void)setBackgroundColor:(UIColor *)color {
-    color = hexColour();
+    color = rebornCustomColour;
     %orig;
 }
 %end
 %hook YTInlineSignInView
 - (void)setBackgroundColor:(UIColor *)color {
-    color = hexColour();
+    color = rebornCustomColour;
     %orig;
 }
 %end
 %hook YTFeedChannelFilterHeaderView
 - (void)setBackgroundColor:(UIColor *)color {
-    color = hexColour();
+    color = rebornCustomColour;
     %orig;
 }
 %end
 %hook YCHLiveChatView
 - (void)setBackgroundColor:(UIColor *)color {
-    color = hexColour();
+    color = rebornCustomColour;
     %orig;
 }
 %end
 %hook YCHLiveChatActionPanelView
 - (void)setBackgroundColor:(UIColor *)color {
-    color = hexColour();
+    color = rebornCustomColour;
     %orig;
 }
 %end
 %hook YTEmojiTextView
 - (void)setBackgroundColor:(UIColor *)color {
-    color = hexColour();
+    color = rebornCustomColour;
     %orig;
 }
 %end
 %hook YTTopAlignedView
 - (void)setBackgroundColor:(UIColor *)color {
-    color = hexColour();
+    color = rebornCustomColour;
     %orig;
 }
 - (void)layoutSubviews {
     %orig();
-    MSHookIvar<YTTopAlignedView *>(self, "_contentView").backgroundColor = hexColour();
+    MSHookIvar<YTTopAlignedView *>(self, "_contentView").backgroundColor = rebornCustomColour;
 }
 %end
 %hook GOODialogView
 - (void)setBackgroundColor:(UIColor *)color {
-    color = hexColour();
+    color = rebornCustomColour;
     %orig;
 }
 %end
 %hook YTNavigationBar
 - (void)setBackgroundColor:(UIColor *)color {
-    color = hexColour();
+    color = rebornCustomColour;
     %orig;
 }
 - (void)setBarTintColor:(UIColor *)color {
-    color = hexColour();
+    color = rebornCustomColour;
     %orig;
 }
 %end
 %hook YTChannelMobileHeaderView
 - (void)setBackgroundColor:(UIColor *)color {
-    color = hexColour();
+    color = rebornCustomColour;
     %orig;
 }
 %end
 %hook YTChannelSubMenuView
 - (void)setBackgroundColor:(UIColor *)color {
-    color = hexColour();
+    color = rebornCustomColour;
     %orig;
 }
 %end
 %hook YTWrapperSplitView
 - (void)setBackgroundColor:(UIColor *)color {
-    color = hexColour();
+    color = rebornCustomColour;
     %orig;
 }
 %end
 %hook YTReelShelfCell
 - (void)setBackgroundColor:(UIColor *)color {
-    color = hexColour();
+    color = rebornCustomColour;
     %orig;
 }
 %end
 %hook YTReelShelfItemView
 - (void)setBackgroundColor:(UIColor *)color {
-    color = hexColour();
+    color = rebornCustomColour;
     %orig;
 }
 %end
 %hook YTReelShelfView
 - (void)setBackgroundColor:(UIColor *)color {
-    color = hexColour();
+    color = rebornCustomColour;
     %orig;
 }
 %end
 %hook YTCommentView
 - (void)setBackgroundColor:(UIColor *)color {
-    color = hexColour();
+    color = rebornCustomColour;
     %orig;
 }
 %end
@@ -1419,7 +1420,7 @@ NSURL *streamURL;
 - (void)layoutSubviews {
 	%orig();
 	MSHookIvar<UIImageView *>(self, "_bannerContainerImageView").hidden = YES;
-    MSHookIvar<UIView *>(self, "_bannerContainerView").backgroundColor = hexColour();
+    MSHookIvar<UIView *>(self, "_bannerContainerView").backgroundColor = rebornCustomColour;
 }
 %end
 %hook YTSearchSuggestionCollectionViewCell
@@ -1569,6 +1570,10 @@ int selectedTabIndex = 0;
 }
 %end
 
+static void colourPrefsChanged(CFNotificationCenterRef center, void *observer, CFStringRef name, const void *object, CFDictionaryRef userInfo) {
+    rebornCustomColour = hexColour();
+}
+
 %ctor {
     @autoreleasepool {
         if ([[NSUserDefaults standardUserDefaults] objectForKey:@"kEnableNoVideoAds"] == nil) {
@@ -1627,6 +1632,8 @@ int selectedTabIndex = 0;
         [unarchiver setRequiresSecureCoding:NO];
         NSString *hexString = [unarchiver decodeObjectForKey:NSKeyedArchiveRootObjectKey];
         if(hexString != nil) {
+            rebornCustomColour = hexColour();
+            CFNotificationCenterAddObserver(CFNotificationCenterGetDarwinNotifyCenter(), NULL, (CFNotificationCallback)colourPrefsChanged, CFSTR("h.ryan.youtubereborn.prefs.colour"), NULL, CFNotificationSuspensionBehaviorCoalesce);
             %init(gColourOptions);
         }
         %init(_ungrouped);


### PR DESCRIPTION
While I probably can't do a PR in one fell swoop, I'll try to integrate reasonable changes from [my own fork](https://github.com/beerpiss/YouTubeReborn).

### Changes
* refactor(gColourOptions): use a variable instead of calling `hexColour()` a million times 
* feat: colour options is now just a table cell with a color well, instead of having its own settings controller
* feat: new colour is applied immediately, no restart required
* fix(Settings): use `+[UIColor clearColor]` for `rebornView` so that the "YT Reborn Settings" button can handle the instantaneous color changes.

### Notes
~~While I have tested this on my fork, I couldn't build and test these changes here because of missing `Jailbreak-Detection-Lib`.~~ Turns out I'm just blind.