### PR TITLE
feat: suspend before exiting

### DIFF
--- a/Controllers/RebornSettingsController.h
+++ b/Controllers/RebornSettingsController.h
@@ -3,3 +3,7 @@
 @interface RebornSettingsController : UITableViewController
 
 @end
+
+@interface UIApplication ()
+- (void)suspend;
+@end

--- a/Controllers/RebornSettingsController.m
+++ b/Controllers/RebornSettingsController.m
@@ -85,6 +85,8 @@ static int __isOSVersionAtLeast(int major, int minor, int patch) { NSOperatingSy
         if(indexPath.row == 0) {
             [[NSUserDefaults standardUserDefaults] removeObjectForKey:@"kYTRebornColourOptionsVTwo"];
             [[NSUserDefaults standardUserDefaults] synchronize];
+            [[UIApplication sharedApplication] suspend];
+            [NSThread sleepForTimeInterval:0.7];
             exit(0);
         }
     }

--- a/Controllers/RootOptionsController.h
+++ b/Controllers/RootOptionsController.h
@@ -3,3 +3,7 @@
 @interface RootOptionsController : UITableViewController
 
 @end
+
+@interface UIApplication ()
+- (void)suspend;
+@end

--- a/Controllers/RootOptionsController.m
+++ b/Controllers/RootOptionsController.m
@@ -355,7 +355,9 @@ static int __isOSVersionAtLeast(int major, int minor, int patch) { NSOperatingSy
 }
 
 - (void)apply {
-    exit(0); 
+    [[UIApplication sharedApplication] suspend];
+    [NSThread sleepForTimeInterval:0.7];
+    exit(0);
 }
 
 - (void)toggleEnableiPadStyleOniPhone:(UISwitch *)sender {


### PR DESCRIPTION
### Changes
* feat: suspend the application before exiting  
  Rationale: because this way there's a normal transition to the home screen instead of a sudden exit (which can be perceived as a crash).

### Notes
`0.7` is an arbitrary number I picked.